### PR TITLE
fix: improve configuration and logging

### DIFF
--- a/s3_upload_server/README.md
+++ b/s3_upload_server/README.md
@@ -45,7 +45,7 @@ An MCP server that provides file upload functionality to AWS S3 with presigned U
           "AWS_ACCESS_KEY_ID":"your access key",
           "AWS_SECRET_ACCESS_KEY":"your secret acess key",
           "AWS_SESSION_TOKEN":"", //optional
-          "EXPIRE_HOURS":144 // 24*7 maximum allowed
+          "EXPIRE_HOURS":"144" // 24*7 maximum allowed
         }
        }
      }

--- a/s3_upload_server/src/server.py
+++ b/s3_upload_server/src/server.py
@@ -124,7 +124,7 @@ def upload_file_to_s3(s3_client, bucket_name: str, file_name: str, file_content:
             ExpiresIn=3600*expire_hours # 7 days in seconds (maximum allowed)
         )
         
-        logger.info(f"Successfully uploaded {file_name} and generated presigned URL")
+        logger.info(f"Successfully uploaded {file_name} and generated presigned URL {presigned_url}")
         return presigned_url
         
     except ClientError as e:
@@ -132,14 +132,14 @@ def upload_file_to_s3(s3_client, bucket_name: str, file_name: str, file_content:
 
 @mcp.tool()
 def upload_file(file_name: str, file_content: str) -> str:
-    """Upload a file to S3 bucket and return a presigned URL with 1-hour expiration
+    """Upload a file to S3 bucket and return a presigned URL with expiration
     
     Args:
         file_name: Name of the file to upload (including extension)
         file_content: Content of the file as a string
     
     Returns:
-        presigned S3 URL of the uploaded file (expires in 1 hour)
+        presigned S3 URL of the uploaded file
     """
     try:
         # Get AWS credentials


### PR DESCRIPTION
- Fix EXPIRE_HOURS value format in README.md config example (string instead of number)
- Add presigned URL to success log message for better debugging visibility
- Update docstring to remove hardcoded expiration time reference

These changes improve configuration clarity and debugging capabilities.

*Issue #, if available:*
Provide int to EXPIRED_HOURS will result in error like
```
 File "/Volumes/workplace/strands-multi-agent-example/.venv/lib/python3.13/site-packages/pydantic/main.py", line 253, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for StdioServerParameters
env.EXPIRE_HOURS
  Input should be a valid string [type=string_type, input_value=144, input_type=int]

```
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
